### PR TITLE
fix: use config-file instead of edit-config to add NSAdvertisingAttri…

### DIFF
--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -38,9 +38,9 @@
         <header-file src="src/ios/AppLovinMAX.h" />
         <source-file src="src/ios/AppLovinMAX.m" />
         
-        <edit-config target="NSAdvertisingAttributionReportEndpoint" file="*-Info.plist" mode="merge">
+        <config-file target="*-Info.plist" parent="NSAdvertisingAttributionReportEndpoint">
             <string>https://postbacks-app.com</string>
-        </edit-config>
+        </config-file>
         
         <podspec>
           <config>


### PR DESCRIPTION
This issue may happen due to the edit-config tags for adding NSAdvertisingAttributionReportEndpoint on plugin.xml file.
Installing "cordova-plugin-applovin-max" for ios
Failed to install 'cordova-plugin-applovin-max': TypeError: doc.find is not a function
at Object.resolveParent platforms/ios/cordova/node_modules/cordova-common/src/util/xml-helpers.js:131:51

As mentioned here https://stackoverflow.com/questions/47404622/edit-config-for-ios-usage-descriptions-doc-find-is-not-a-function.
 
A solution for that issue is to use config-file tags instead of edit-config.