### PR TITLE
destroyMRec() - missing argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Versions
 
+## 1.1.2
+    * Fix `destroyMRec` API by adding the missing argument.
 ## 1.1.1
     * Fix `plugins.xml` using a deprecated CocoaPods repository.
 ## 1.1.0

--- a/plugin/www/applovinmax.js
+++ b/plugin/www/applovinmax.js
@@ -281,7 +281,7 @@ var AppLovinMAX = {
         callNative('hideMRec', [adUnitId]);
     },
 
-    destroyMRec: function () {
+    destroyMRec: function (adUnitId) {
         callNative('destroyMRec', [adUnitId]);
     },
 


### PR DESCRIPTION
destroyMRec() - missing argument `adUnitId` in `applovinmax.js`.