### PR TITLE
fix: showAdView NPE

### DIFF
--- a/plugin/src/android/AppLovinMAX.java
+++ b/plugin/src/android/AppLovinMAX.java
@@ -923,11 +923,12 @@ public class AppLovinMAX
             // The publisher may have requested to show the banner before it was created. Now that the banner is created, show it.
             if ( mAdUnitIdsToShowAfterCreate.contains( adUnitId ) )
             {
-                showAdView( adUnitId, adFormat, null );
                 mAdUnitIdsToShowAfterCreate.remove( adUnitId );
+                showAdView( adUnitId, adFormat, callbackContext );
+                
+            } else {
+                callbackContext.success();
             }
-
-            callbackContext.success();
         } );
     }
 


### PR DESCRIPTION
Fixes https://github.com/AppLovin/AppLovin-MAX-Cordova/issues/43

Stack trace reported by android play store:
Exception java.lang.NullPointerException: Attempt to invoke virtual method 'void org.apache.cordova.CallbackContext.success()' on a null object reference
  at com.applovin.cordova.AppLovinMAX.lambda$showAdView$4$AppLovinMAX (AppLovinMAX.java:997)
  at com.applovin.cordova.-$$Lambda$AppLovinMAX$Mko6byzlR2KjXtQA0CkRpxAY-RA.run
  at android.app.Activity.runOnUiThread (Activity.java:7512)
  at com.applovin.cordova.AppLovinMAX.showAdView (AppLovinMAX.java:980)
  at com.applovin.cordova.AppLovinMAX.lambda$createAdView$1$AppLovinMAX (AppLovinMAX.java:926)
  at com.applovin.cordova.-$$Lambda$AppLovinMAX$PTG6LauycdJocU30dK4gPxRc5XU.run
  at android.os.Handler.handleCallback (Handler.java:942)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:211)
  at android.os.Looper.loop (Looper.java:300)
  at android.app.ActivityThread.main (ActivityThread.java:8296)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:559)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:954)


When showAdView was called from createAdView, null was passed for callbackContext. 
To not alter the showAdView call to callbackContext.success() at its end, I pass createAdView's callbackContext to be called at the end of showAdView, and createAdView only calls success itself if not passed to showAdView.

This is a suggestion instead of just testing (callbackContext != null) in showAdView. 
Might be over engineered. Your call :) 