### PR TITLE
config/increase_ios_sdk_to_12.4.1

### DIFF
--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -43,7 +43,7 @@
             <source url="https://github.com/CocoaPods/Specs.git"/>
           </config>
           <pods use-frameworks="true">
-            <pod name="AppLovinSDK" spec="12.3.1" />/>
+            <pod name="AppLovinSDK" spec="12.4.1" />
           </pods>
         </podspec>
     </platform>


### PR DESCRIPTION
We've received a message from Applovin about Apple's new privacy manifest:

All developers using AppLovin iOS SDK, for mediation and/or monetization purposes, should update to the latest version, [12.4.1](https://go.applovin.com/e3t/Ctc/5C+113/cD4wH04/VW3GMS2pqQX3W4C37-T3vyRR7W2C4PM95cwx6lN5XFYng3qgyTW8wLKSR6lZ3p-W39LtsJ2Dx0LMW3smXBp6TJppQN8QFRwhZl9TWW68btkr1XptttW2XrPbl2447ZtVjcbPF4m6xy8VznfVb1ysNvKW1QsTnm6xl6L_W2SVQJF59Vy2BW1dKTg03qWczPW7ZFZX05N13MvW7qXMyF4hFTMYW7DrSSk2_p0pJW58kWzW28SWvsW2BLlbZ4FhLd1VWmr2d95CC98W4GJjz01rR4KvW4SGglY8S2393W6drD_d5TVPgpW5fFfx916tmN_W6Ttk2j11Vb6NW82nH2b7rrQvQW537skN6XvWy0W6czT0g1g3DP-W8bPtBL8f-HfhW8Xc4wH94hkfKVD-gfk2nVnGpW78HyYj3_Zs_zf5QH5Qb04), to ensure compliance with the latest Privacy Manifest requirements.

Here's a PR with the ios sdk version increase. 
From [ios sdk release note](https://github.com/AppLovin/AppLovin-MAX-SDK-iOS/releases), there doesn't seem to have breaking changes.
Tested localy with banners & interstitials, not with rewarded ads.